### PR TITLE
Update worker.Dockerfile

### DIFF
--- a/app/docker/worker.Dockerfile
+++ b/app/docker/worker.Dockerfile
@@ -16,6 +16,7 @@ RUN apt -y install python3-pip
 # Install docker
 RUN apt -y install docker
 RUN apt -y install docker-compose
+RUN chmod -R 755 /certificates
 
 # Clone docker-tc
 RUN mkdir /app/docker-tc


### PR DESCRIPTION
Fixing the cert files write permission error

*Issue #, if available:*

*Description of changes:*
Fixing error where python script cannot write to certificate files and returning permission denied instead

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
